### PR TITLE
Add config vars to rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,8 +14,8 @@ import filesize from 'rollup-plugin-filesize';
 // entry: `site/javascript/${entries}`,
 // Create default config object
 let config = {
-    entry       : `site/javascript/${process.env.entry}`,
-    dest        : `dist/js/${process.env.entry}`,
+    entry       : `${process.env.npm_package_config_src_js}/${process.env.entry}`,
+    dest        : `${process.env.npm_package_config_dest_js}/${process.env.entry}`,
     format      : 'umd',
     globals     : {}, // specify globals in .eslintrc to ignore linting errors
     plugins     : [


### PR DESCRIPTION
 - use source and destination variables for javascript files defined in package.json in rollup config